### PR TITLE
fix(build) Add missing NTP Perl module

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ IO::Socket::SSL
 JE
 JSON::XS
 Net::FTPSSL
+Net::NTP
 Net::SSLeay
 Tie::RefHash::Weak
 Win32::Job

--- a/build_centreon_plugins_32.bat
+++ b/build_centreon_plugins_32.bat
@@ -82,6 +82,7 @@ CMD /C %PERL_INSTALL_DIR%\perl\site\bin\pp --lib=centreon-plugins\ ^
 -M JE ^
 -M JSON::XS ^
 -M Net::FTPSSL ^
+-M Net::NTP ^
 -M Net::SSLeay ^
 -M Tie::RefHash::Weak ^
 -M Win32::Job ^

--- a/build_centreon_plugins_64.bat
+++ b/build_centreon_plugins_64.bat
@@ -80,6 +80,7 @@ CMD /C %PERL_INSTALL_DIR%\perl\site\bin\pp --lib=centreon-plugins\ ^
 -M JE ^
 -M JSON::XS ^
 -M Net::FTPSSL ^
+-M Net::NTP ^
 -M Net::SSLeay ^
 -M Tie::RefHash::Weak ^
 -M Win32::Job ^


### PR DESCRIPTION
Hi,

Let's add `Net:NTP` Perl module, which is missing at least for `os::windows::local::plugin`, `time` mode.
Works perfectly fine with.

Thank you 👍